### PR TITLE
Handle minLevel with inlineFirstLevel style

### DIFF
--- a/main.js
+++ b/main.js
@@ -152,8 +152,11 @@ function getMarkdownNestedListFromHeadings(headings, options) {
 }
 
 function getMarkdownInlineFirstLevelFromHeadings(headings, options) {
+  const minLevel = options.minLevel > 0
+    ? options.minLevel
+    : Math.min(...headings.map((heading) => heading.level))
   const items = headings
-    .filter((heading) => heading.level === 1)
+    .filter((heading) => heading.level === minLevel)
     .map((heading) => {
       return getMarkdownHeading(heading, options)
     })

--- a/test/headings.test.js
+++ b/test/headings.test.js
@@ -160,6 +160,29 @@ Title 1 level 1 | Title 2 level 1 | Title 3 level 1
 `)
     expect(md).toEqual(expectedMd)
   })
+
+  test('Returns flat list with custom level', () => {
+    const options = parseOptionsFromSourceText('')
+    options.style = 'inlineFirstLevel'
+    options.includeLinks = false
+    options.minLevel = 3
+    const md = getMarkdownFromHeadings(testStandardHeadings, options)
+    const expectedMd = sanitizeMd(`
+Title 1 level 3
+`)
+    expect(md).toEqual(expectedMd)
+  })
+
+  test('Returns flat list with default level', () => {
+    const options = parseOptionsFromSourceText('')
+    options.style = 'inlineFirstLevel'
+    options.includeLinks = false
+    const md = getMarkdownFromHeadings(testHeadingsWithoutFirstLevel, options)
+    const expectedMd = sanitizeMd(`
+Title 1 level 2 | Title 2 level 2 | Title 3 level 2
+`)
+    expect(md).toEqual(expectedMd)
+  })
 })
 
 function sanitizeMd(md) {


### PR DESCRIPTION
Look for the right minimum level and check `minLevel` when `style:inlineFirstLevel` (fix #39)