### PR TITLE
Inline TOC title when inlineFirstLevel

### DIFF
--- a/main.js
+++ b/main.js
@@ -137,7 +137,8 @@ function getMarkdownFromHeadings(headings, options) {
   }
   let titleMarkdown = ''
   if (options.title && options.title.length > 0) {
-    titleMarkdown += `${options.title}\n`
+    const titleSeparator = options.style === 'inlineFirstLevel' ? ' ' : '\n'
+    titleMarkdown += `${options.title}${titleSeparator}`
   }
   const markdownHeadings = markdownHandlersByStyle[options.style](headings, options)
   if (markdownHeadings === null) {

--- a/test/headings.test.js
+++ b/test/headings.test.js
@@ -215,6 +215,18 @@ Title 1 level 2 | Title 2 level 2 | Title 3 level 2
 `)
     expect(md).toEqual(expectedMd)
   })
+
+  test('Returns flat list with title', () => {
+    const options = parseOptionsFromSourceText('')
+    options.style = 'inlineFirstLevel'
+    options.title = 'Some title:'
+    options.includeLinks = false
+    const md = getMarkdownFromHeadings(testHeadingsWithoutFirstLevel, options)
+    const expectedMd = sanitizeMd(`
+Some title: Title 1 level 2 | Title 2 level 2 | Title 3 level 2
+`)
+    expect(md).toEqual(expectedMd)
+  })
 })
 
 function sanitizeMd(md) {


### PR DESCRIPTION
Inline the TOC title when `style: inlineFirstLevel` (fix #59)

Input:

```
title: Table of contents ✨:
style: inlineFirstLevel
```

```md
# Title 1
# Title 2
## test 2
## test 3
```

Output:

![CleanShot 2025-02-23 at 14 12 51@2x](https://github.com/user-attachments/assets/63650b57-0217-4fe2-b5ca-4bba5de29845)
