### PR TITLE
Fix italic stripping

### DIFF
--- a/src/markdown.js
+++ b/src/markdown.js
@@ -59,7 +59,7 @@ function getFormattedMarkdownHeading(label, options) {
 function stripMarkdown(text) {
   return text
     .replaceAll('*', '')
-    .replaceAll('_', '')
+    .replaceAll(/(\W|^)_+(\S)(.*?\S)?_+(\W|$)/g, '$1$2$3$4')
     .replaceAll('`', '')
     .replaceAll('==', '')
     .replaceAll('~~', '')

--- a/test/headings.nested.test.js
+++ b/test/headings.nested.test.js
@@ -112,7 +112,7 @@ describe('Nested headings', () => {
     const options = parseOptionsFromSourceText('')
     const md = getMarkdownFromHeadings(testHeadingsWithSpecialChars, options)
     const expectedMd = sanitizeMd(`
-- [[#Title 1 \`level 1\` {with special chars}, **bold**, _italic_, a-tag, ==highlighted== and ~~strikethrough~~ text|Title 1 level 1 {with special chars}, bold, italic,#a-tag, highlighted and strikethrough text]]
+- [[#Title 1 \`level 1\` {with special chars}, **bold**, _some_italic_, a-tag, ==highlighted== and ~~strikethrough~~ text|Title 1 level 1 {with special chars}, bold, some_italic,#a-tag, highlighted and strikethrough text]]
   - [[#Title 1 level 2 <em style="color: black">with HTML</em>|Title 1 level 2 <em style="color: black">with HTML</em>]]
   - [[#Title 1 level 2 wikilink1 wikilink2 wikitext2 [mdlink](https://mdurl)|Title 1 level 2 wikilink1 wikitext2 mdlink]]
   - [[#Title 1 level 2 malformedlink a pi pe and [other chars]|Title 1 level 2 malformedlink a pi-pe - and [other chars]]]
@@ -125,7 +125,7 @@ describe('Nested headings', () => {
     options.includeLinks = false
     const md = getMarkdownFromHeadings(testHeadingsWithSpecialChars, options)
     const expectedMd = sanitizeMd(`
-- Title 1 \`level 1\` {with special chars}, **bold**, _italic_,#a-tag, ==highlighted== and ~~strikethrough~~ text
+- Title 1 \`level 1\` {with special chars}, **bold**, _some_italic_,#a-tag, ==highlighted== and ~~strikethrough~~ text
   - Title 1 level 2 <em style="color: black">with HTML</em>
   - Title 1 level 2 [[wikilink1]] [[wikilink2|wikitext2]] [mdlink](https://mdurl)
   - Title 1 level 2 [[malformedlink a pi|pe | and [other chars]

--- a/test/utils.js
+++ b/test/utils.js
@@ -24,7 +24,7 @@ const testHeadingsWithoutFirstLevel = [
 const testHeadingsWithSpecialChars = [
   {
     heading:
-      'Title 1 `level 1` {with special chars}, **bold**, _italic_,#a-tag, ==highlighted== and ~~strikethrough~~ text',
+      'Title 1 `level 1` {with special chars}, **bold**, _some_italic_,#a-tag, ==highlighted== and ~~strikethrough~~ text',
     level: 1,
   },
   { heading: 'Title 1 level 2 <em style="color: black">with HTML</em>', level: 2 },


### PR DESCRIPTION
Fix italic stripping so that `_some_italic_` becomes `some_italic` instead of `someitalic` in link text (as markdown is not rendered in a wikilink label)